### PR TITLE
Enforce strict JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+coverage

--- a/index.js
+++ b/index.js
@@ -38,7 +38,16 @@ var plugin = module.exports = function () {
         if (!first) return this.emit('end');
         // If only one document emit it unwrapped, unless always returning an array.
         if (!multiple && alwaysArray) this.emit('data', '[');
-        if (!multiple) this.emit('data', JSON.stringify(first));
+        if (!multiple) {
+          var payload;
+          if (isSingleValue(first)) {
+            payload = envelopeSingleValue(first);
+          }
+          else {
+            payload = first;
+          }
+          this.emit('data', JSON.stringify(payload));           
+        }
         // For greater than one document, emit the closing array.
         else this.emit('data', ']');
         if (!multiple && alwaysArray) this.emit('data', ']');
@@ -47,6 +56,20 @@ var plugin = module.exports = function () {
       }
     );
   };
+  
+  function isSingleValue(value) {
+    if (!value) {
+      return false;
+    }
+    var ty = typeof value;  
+    if ('number' === ty || 'string' === ty || 'boolean' === ty ) {
+         return true;
+    }
+    return false;
+  }
+  function envelopeSingleValue(data) {
+    return  { value : data };
+  }
 
   // Default parser.  Parses incoming JSON string into an object or objects.
   // Works whether an array or single object is sent as the request body.  It's

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Baucis uses this to parse and format streams of JSON.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha"
   },
   "keywords": [
     "baucis", "stream", "json", "parse", "parser", "format"
@@ -14,6 +15,11 @@
   "dependencies": {
     "event-stream": "~3.2.2"
   },
+ "devDependencies": {
+    "expect.js": "~0.3.1",
+    "istanbul": "^0.3.13",
+    "mocha": "~2.2.4"
+  },  
   "repository": {
     "type": "git",
     "url": "https://github.com/wprl/baucis-json.git"

--- a/test/parseTest.js
+++ b/test/parseTest.js
@@ -1,0 +1,56 @@
+var expect = require('expect.js');
+var sut = require('../index');
+
+var baucisMock = {
+	Error: { 
+		BadSyntax : function () {}
+	},
+	setFormatter: function(mime, fn) { 
+		this.formatter = fn;
+	},
+	setParser: function(mime, fn) { 
+		this.parser = fn; 
+	}
+};
+
+sut.apply(baucisMock);
+
+function parse(obj, cb) {
+	var response = [];
+	var f1 = baucisMock.parser();
+	
+	f1.on('data', function(chunk) {
+		if (chunk) {
+			return response.push(chunk);
+		}
+	});
+	f1.on('error', function(err) {
+		return cb(err, null);
+	});
+	f1.on('end', function(chunk) {
+		if (chunk) {
+			response.push(chunk);		
+		}
+		return cb(null, response);
+	});
+	
+	f1.write(obj);
+	f1.end();
+}
+
+
+describe('parse test', function () {
+	it('parse object', function (done) {
+		var sample = '{"a":"name","b":7.1,"c":true,"d":null,"e":{"name":"spook"}}';
+		parse(sample, function(err, objArray) {
+			expect(err).to.be(null);
+			expect(objArray[0]).to.have.property('a', 'name');
+			expect(objArray[0]).to.have.property('b', 7.1);
+			expect(objArray[0]).to.have.property('c', true);
+			expect(objArray[0]).to.have.property('d', null);
+			expect(objArray[0]).to.have.property('e');
+			expect(objArray[0].e).to.have.property('name', 'spook');
+			done();			
+		});
+	});	
+});

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -104,7 +104,7 @@ describe('primitive values serialization', function () {
 		var testObject = 3.14;
 		format(testObject, function(err, result) {
 			expect(err).to.be(null);
-			expect(result).to.be('3.14');
+			expect(result).to.be('{"value":3.14}');
 			done();
 		});
 	});
@@ -113,7 +113,7 @@ describe('primitive values serialization', function () {
 		var testObject = 'enterprise';
 		format(testObject, function(err, result) {
 			expect(err).to.be(null);
-			expect(result).to.be('"enterprise"');
+			expect(result).to.be('{"value":"enterprise"}');
 			done();
 		});
 	});
@@ -122,7 +122,7 @@ describe('primitive values serialization', function () {
 		var testObject = true;
 		format(testObject, function(err, result) {
 			expect(err).to.be(null);
-			expect(result).to.be('true');
+			expect(result).to.be('{"value":true}');
 			done();
 		});
 	});

--- a/test/serializeTest.js
+++ b/test/serializeTest.js
@@ -1,0 +1,131 @@
+var expect = require('expect.js');
+var sut = require('../index');
+
+var baucisMock = {
+	Error: { 
+		BadSyntax : function () {}
+	},
+	setFormatter: function(mime, fn) { 
+		this.formatter = fn;
+	},
+	setParser: function(mime, fn) { 
+		this.parser = fn; 
+	}
+};
+
+function format(obj, cb) {
+	var response = '';
+	var f1 = baucisMock.formatter();
+	
+	f1.on('data', function(chunk) {
+		if (chunk) {
+			response += chunk;
+		}
+	});
+	f1.on('end', function(chunk) {
+		if (chunk) {
+			response += chunk;				
+		}
+		cb(null, response);
+	});
+	
+	f1.write(obj);
+	f1.end();
+}
+
+function formatArray(array, cb) {
+	var response = '';
+	var f1 = baucisMock.formatter();
+	
+	f1.on('data', function(chunk) {
+		if (chunk) {
+			response += chunk;
+		}
+	});
+	f1.on('end', function(chunk) {
+		if (chunk) {
+			response += chunk;				
+		}
+		cb(null, response);
+	});
+	
+	for(var i=0; i<array.length; i++) {
+		var obj = array[i];	
+		f1.write(obj);
+	}
+	f1.end();
+}
+
+
+sut.apply(baucisMock);
+
+describe('object serialization', function () {
+	it('serialize object', function (done) {
+		var testObject = {a: 'name', b: 7.1, c:true, d:null, e: { name: 'spook'} };
+		format(testObject, function(err, result) {
+			expect(err).to.be(null);
+			expect(result).to.be('{"a":"name","b":7.1,"c":true,"d":null,"e":{"name":"spook"}}');
+			done();
+		});
+	});
+});
+
+describe('array serialization', function () {		
+	it('serialize array of objects', function (done) {
+		var testObject = {a: 'name', b: 7.1, c:true, d:null, e: { name: 'spook'} };
+		var arraySample = [testObject, testObject, testObject];
+		formatArray(arraySample, function(err, result) {
+			expect(err).to.be(null);
+			expect(result).to.be('[{"a":"name","b":7.1,"c":true,"d":null,"e":{"name":"spook"}},\n{"a":"name","b":7.1,"c":true,"d":null,"e":{"name":"spook"}},\n{"a":"name","b":7.1,"c":true,"d":null,"e":{"name":"spook"}}]');
+			done();
+		});
+	});
+	it('serialize array of numbers', function (done) {
+		var arraySample = [1, -2.0, 3.010];
+		formatArray(arraySample, function(err, result) {
+			expect(err).to.be(null);
+			expect(result).to.be('[1,\n-2,\n3.01]');
+			done();
+		});
+	});
+});
+
+describe('primitive values serialization', function () {
+	it('serialize null', function (done) {
+		var testObject = null;
+		format(testObject, function(err, result) {
+			expect(err).to.be(null);
+			expect(result).to.be('');
+			done();
+		});
+	});
+	
+	it('serialize number', function (done) {
+		var testObject = 3.14;
+		format(testObject, function(err, result) {
+			expect(err).to.be(null);
+			expect(result).to.be('3.14');
+			done();
+		});
+	});
+
+	it('serialize string', function (done) {
+		var testObject = 'enterprise';
+		format(testObject, function(err, result) {
+			expect(err).to.be(null);
+			expect(result).to.be('"enterprise"');
+			done();
+		});
+	});
+
+	it('serialize boolean', function (done) {
+		var testObject = true;
+		format(testObject, function(err, result) {
+			expect(err).to.be(null);
+			expect(result).to.be('true');
+			done();
+		});
+	});
+	
+});
+	


### PR DESCRIPTION
Accordingly to http://json.org/ the only two structures allowed in JSON are arrays and objects. Single primitive values must be always encapsulated. See discussion here: https://github.com/wprl/baucis/issues/271

This pull-request enforces this adding unit-testing to verify the working implementation. 